### PR TITLE
Iso C++ changes

### DIFF
--- a/include/hiscore.h
+++ b/include/hiscore.h
@@ -50,7 +50,7 @@ public:
 
 	void clear();								// Clear the list
 	void sort();								// Sort the list
-	int addName(char *name, long score);		// Add a record
+	int addName(const char *name, long score);		// Add a record
 	void save(const String &file);					// Save the list
 	void load(const String &file);					// Load the list
 	void updateOverlay();						// Update the overlay

--- a/src/hiscore.cpp
+++ b/src/hiscore.cpp
@@ -171,7 +171,7 @@ void HiscoreList::load(const String &file) {
 
 
 // Add a name to the list. Returns the place.
-int HiscoreList::addName(char *name, long score) {
+int HiscoreList::addName(const char *name, long score) {
 	// Check if we qualify
 	if(mList[NUM_NAMES-1].score >= score)
 		return -1;

--- a/src/ogrelistener.cpp
+++ b/src/ogrelistener.cpp
@@ -127,7 +127,7 @@ OgreAppFrameListener::OgreAppFrameListener(OgreApplication *app, RenderWindow *w
 
 
 	// Show debug info?
-	if(GameApplication::mGameConfig->GetValue("graphics", "debug_info", "off") == "on") {
+	if(strcmp(GameApplication::mGameConfig->GetValue("graphics", "debug_info", "off"), "on") == 0) {
 		showDebugOverlay(true);
 		mStatsOn = true;
 	}


### PR DESCRIPTION
Iso C++ does not allow to compare string literals, this will result in undefined behavior.
Fixed that by using `strcmp`.